### PR TITLE
Removing  MediatR

### DIFF
--- a/FSTime.sln
+++ b/FSTime.sln
@@ -24,6 +24,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InfrastructureTests", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FSTime.Services.DatabaseMigration", "src\FSTime.Services.DatabaseMigration\FSTime.Services.DatabaseMigration.csproj", "{BF7D9628-2A09-46CD-A180-B34FF53BDBBE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlintSoft.CQRS", "FlintSoft.CQRS\FlintSoft.CQRS.csproj", "{55ABDA60-B6A3-4F1A-8B1A-65C3C428428C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libs", "Libs", "{A5E6C5E5-AF97-4AB2-A84C-793EF974FEE4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +70,10 @@ Global
 		{BF7D9628-2A09-46CD-A180-B34FF53BDBBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF7D9628-2A09-46CD-A180-B34FF53BDBBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF7D9628-2A09-46CD-A180-B34FF53BDBBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55ABDA60-B6A3-4F1A-8B1A-65C3C428428C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55ABDA60-B6A3-4F1A-8B1A-65C3C428428C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55ABDA60-B6A3-4F1A-8B1A-65C3C428428C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55ABDA60-B6A3-4F1A-8B1A-65C3C428428C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -74,6 +82,7 @@ Global
 		{D3738F9A-BF78-49B5-A48D-C5AB537425CA} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{481C7D6D-8723-4016-804E-80A4A0478BF6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{45148BE1-7003-461C-B5DB-765D793E8775} = {AEF797F1-FCC0-4A5F-97CF-56799B70A4DA}
+		{55ABDA60-B6A3-4F1A-8B1A-65C3C428428C} = {A5E6C5E5-AF97-4AB2-A84C-793EF974FEE4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BE658FED-F303-41E4-9DF7-F638F33538EE}

--- a/FlintSoft.CQRS/Extensions.cs
+++ b/FlintSoft.CQRS/Extensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Reflection;
+
+namespace FlintSoft.CQRS;
+
+public static class Extensions
+{
+    public static IHostApplicationBuilder? AddFlintSoftCQRS(this IHostApplicationBuilder? builder, Assembly assembly)
+    {
+        //var assembly = Assembly.GetExecutingAssembly();
+
+        var handlers = assembly
+           .DefinedTypes
+           .Where(type => type is { IsAbstract: false, IsInterface: false })
+           .Where(type => type.GetInterfaces()
+               .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequestHandler<,>)))
+           .Select(type => ServiceDescriptor.Transient(type.GetInterfaces()
+               .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IRequestHandler<,>)), type))
+           .ToList();
+
+        handlers.ForEach(r =>
+        {
+            builder?.Services.Add(r);
+        });
+
+        return builder;
+    }
+}

--- a/FlintSoft.CQRS/FlintSoft.CQRS.csproj
+++ b/FlintSoft.CQRS/FlintSoft.CQRS.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/FlintSoft.CQRS/IRequest.cs
+++ b/FlintSoft.CQRS/IRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace FlintSoft.CQRS;
+
+public interface IRequest<TResponse>
+{
+}

--- a/FlintSoft.CQRS/IRequestHandler.cs
+++ b/FlintSoft.CQRS/IRequestHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace FlintSoft.CQRS;
+
+public interface IRequestHandler<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/AppHost/AppHost.csproj
+++ b/src/AppHost/AppHost.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.1.0" />
-    <PackageReference Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="9.2.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.2.0" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="9.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FSTime.Api/Authorization/PermissionEndpoints.cs
+++ b/src/FSTime.Api/Authorization/PermissionEndpoints.cs
@@ -1,8 +1,12 @@
+using ErrorOr;
+using FlintSoft.CQRS;
 using FlintSoft.Endpoints;
+
 using FSTime.Api.Common.Errors;
 using FSTime.Application.Authorization.Queries;
 using FSTime.Application.Common;
-using MediatR;
+using FSTime.Domain.AuthorizationAggregate;
+using Microsoft.AspNetCore.Mvc;
 
 namespace FSTime.Api.Authorization;
 
@@ -12,7 +16,7 @@ public class PermissionEndpoints : IEndpoint
     {
         var grp = app.MapGroup("permissions");
 
-        grp.MapGet("/my", async (HttpContext context, IMediator mediator) =>
+        grp.MapGet("/my", async (HttpContext context, [FromServices] IRequestHandler<GetPermissionsForUser.Query, ErrorOr<List<Permission>>> handler) =>
         {
             var tenantId = context.GetTenantIdFromHttpContext();
             if (tenantId is null) return Results.Unauthorized();
@@ -21,7 +25,7 @@ public class PermissionEndpoints : IEndpoint
 
             if (!Guid.TryParse(userId, out var parsedUserId)) return Results.Unauthorized();
 
-            var result = await mediator.Send(new GetPermissionsForUser.Query(tenantId.Value, parsedUserId));
+            var result = await handler.Handle(new GetPermissionsForUser.Query(tenantId.Value, parsedUserId));
 
             return result.Match(
                 permissions => Results.Ok(permissions),
@@ -29,17 +33,35 @@ public class PermissionEndpoints : IEndpoint
             );
         }).RequireAuthorization();
 
-        grp.MapGet("/{userId}", async (Guid userId, HttpContext context, IMediator mediator) =>
+        grp.MapGet("/{userId}", async (Guid userId, HttpContext context, [FromServices] IRequestHandler<GetPermissionsForUser.Query, ErrorOr<List<Permission>>> handler) =>
         {
             var tenantId = context.GetTenantIdFromHttpContext();
             if (tenantId is null) return Results.Unauthorized();
 
-            var result = await mediator.Send(new GetPermissionsForUser.Query(tenantId.Value, userId));
+            var result = await handler.Handle(new GetPermissionsForUser.Query(tenantId.Value, userId));
 
             return result.Match(
                 permissions => Results.Ok(permissions),
                 error => Results.BadRequest(error.ToProblemDetails())
             );
+        }).RequireAuthorization("TENANT.ADMIN");
+
+        grp.MapGet("/groups", async ([FromServices] IRequestHandler<GetGroups.Query, ErrorOr<List<string>>> handler) =>
+        {
+            var result = await handler.Handle(new GetGroups.Query());
+
+            return result.Match(
+                groups => Results.Ok(groups),
+                error => Results.BadRequest(error.ToProblemDetails()));
+        }).RequireAuthorization("TENANT.ADMIN");
+
+        grp.MapGet("/actions/{group}", async (string group, [FromServices] IRequestHandler<GetActions.Query, ErrorOr<List<string>>> handler) =>
+        {
+            var result = await handler.Handle(new GetActions.Query(group));
+
+            return result.Match(
+                groups => Results.Ok(groups),
+                error => Results.BadRequest(error.ToProblemDetails()));
         }).RequireAuthorization("TENANT.ADMIN");
     }
 }

--- a/src/FSTime.Api/Employees/Endpoints.cs
+++ b/src/FSTime.Api/Employees/Endpoints.cs
@@ -1,10 +1,11 @@
+using ErrorOr;
+using FlintSoft.CQRS;
 using FlintSoft.Endpoints;
 using FSTime.Api.Common.Errors;
 using FSTime.Application.Common;
 using FSTime.Application.Employees.Commands;
 using FSTime.Application.Employees.Queries;
 using FSTime.Contracts.Employees;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FSTime.Api.Employees;
@@ -15,60 +16,60 @@ public class Endpoints : IEndpoint
     {
         var grp = app.MapGroup("employees");
 
-        grp.MapGet("", async ([FromQuery] Guid company, IMediator mediator) =>
+        grp.MapGet("", async ([FromQuery] Guid company, [FromServices] IRequestHandler<GetAllEmployees.Query, ErrorOr<List<EmployeeResponse>>> handler) =>
         {
-            var result = await mediator.Send(new GetAllEmployees.Query(company));
+            var result = await handler.Handle(new GetAllEmployees.Query(company));
 
             return result.Match(
                 emps => Results.Ok(emps),
                 error => Results.BadRequest(error.ToProblemDetails())
             );
-        }).RequireAuthorization("EMPLOYEE.READ");
+        }).RequireAuthorization("EMPLOYEE.Read");
 
-        grp.MapGet("/{id}", async (Guid id, IMediator mediator) =>
+        grp.MapGet("/{id}", async (Guid id, [FromServices] IRequestHandler<GetEmployee.Query, ErrorOr<EmployeeResponse>> handler) =>
         {
-            var result = await mediator.Send(new GetEmployee.Query(id));
+            var result = await handler.Handle(new GetEmployee.Query(id));
 
             return result.Match(
                 emp => Results.Ok(emp),
                 error => Results.BadRequest(error.ToProblemDetails())
             );
-        }).RequireAuthorization("EMPLOYEE.READ_SELF, EMPLOYEE.READ");
+        }).RequireAuthorization("EMPLOYEE.Read_SELF, EMPLOYEE.Read");
 
-        grp.MapPost("", async (CreateEmployeeRequest request, [FromQuery] Guid company, IMediator mediator) =>
+        grp.MapPost("", async (CreateEmployeeRequest request, [FromQuery] Guid company, [FromServices] IRequestHandler<CreateEmployee.Command, ErrorOr<EmployeeResponse>> handler) =>
         {
-            var result = await mediator.Send(new CreateEmployee.Command(company, request.FirstName, request.LastName,
+            var result = await handler.Handle(new CreateEmployee.Command(company, request.FirstName, request.LastName,
                 request.MiddleName));
 
             return result.Match(
                 emp => Results.Created($"companies/{emp.Id}", emp),
                 error => Results.BadRequest(error.ToProblemDetails())
             );
-        }).RequireAuthorization("EMPLOYEE.MODIFY");
+        }).RequireAuthorization("EMPLOYEE.Update");
 
-        grp.MapPost("/assignUser", async (AssignUserRequest request, HttpContext context, IMediator mediator) =>
+        grp.MapPost("/assignUser", async (AssignUserRequest request, HttpContext context, [FromServices] IRequestHandler<AssignUserToEmployee.Command, ErrorOr<EmployeeResponse>> handler) =>
         {
             var tenantId = context.GetTenantIdFromHttpContext();
             if (tenantId is null) return Results.Unauthorized();
 
             var result =
-                await mediator.Send(
+                await handler.Handle(
                     new AssignUserToEmployee.Command(request.EmployeeId, request.UserId, (Guid)tenantId));
             return result.Match(
                 emp => Results.Ok(emp),
                 error => Results.BadRequest(error.ToProblemDetails())
             );
-        }).RequireAuthorization("EMPLOYEE.MODIFY");
+        }).RequireAuthorization("EMPLOYEE.Update");
 
-        grp.MapPost("/addworkschedule", async (AddWorkscheduleRequest request, IMediator mediator) =>
+        grp.MapPost("/addworkschedule", async (AddWorkscheduleRequest request, [FromServices] IRequestHandler<AddWorkschedule.Command, ErrorOr<EmployeeResponse>> handler) =>
         {
-            var result = await mediator.Send(new AddWorkschedule.Command(request.EmployeeId, request.WorkscheduleId,
+            var result = await handler.Handle(new AddWorkschedule.Command(request.EmployeeId, request.WorkscheduleId,
                 request.ValidFrom.ToDateTime(TimeOnly.MinValue).ToUniversalTime()));
 
             return result.Match(
                 emp => Results.Ok(emp),
                 error => Results.BadRequest(error.ToProblemDetails())
             );
-        }).RequireAuthorization("EMPLOYEE.MODIFY");
+        }).RequireAuthorization("EMPLOYEE.Update");
     }
 }

--- a/src/FSTime.Api/FSTime.Api.csproj
+++ b/src/FSTime.Api/FSTime.Api.csproj
@@ -9,15 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="FlintSoft.Endpoints" Version="0.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\FlintSoft.CQRS\FlintSoft.CQRS.csproj" />
     <ProjectReference Include="..\FSTime.Application\FSTime.Application.csproj" />
     <ProjectReference Include="..\FSTime.Contracts\FSTime.Contracts.csproj" />
     <ProjectReference Include="..\FSTime.Domain\FSTime.Domain.csproj" />

--- a/src/FSTime.Api/Program.cs
+++ b/src/FSTime.Api/Program.cs
@@ -3,7 +3,6 @@ using FSTime.Api.Common.Errors;
 using FSTime.Application;
 using FSTime.Infrastructure;
 using System.Reflection;
-using FSTime.Api;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/FSTime.Api/Users/Endpoints.cs
+++ b/src/FSTime.Api/Users/Endpoints.cs
@@ -1,8 +1,10 @@
-﻿using FlintSoft.Endpoints;
+﻿using ErrorOr;
+using FlintSoft.CQRS;
+using FlintSoft.Endpoints;
 using FSTime.Api.Common.Errors;
 using FSTime.Application.Users.Commands;
 using FSTime.Contracts.Users;
-using MediatR;
+using Microsoft.AspNetCore.Mvc;
 
 namespace FSTime.Api.Users;
 
@@ -11,28 +13,28 @@ public class Endpoints : IEndpoint
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
         var grp = app.MapGroup("users");
-        
-        grp.MapPost("", async (RegisterUserRequest request, IMediator mediator, HttpContext context) =>
+
+        grp.MapPost("", async ([FromBody] RegisterUserRequest request, HttpContext context, [FromServices] IRequestHandler<CreateUser.Command, ErrorOr<RegisterUserResult>> handler) =>
         {
             var command = new CreateUser.Command(request.username, request.password, request.email);
 
-            var result = await mediator.Send(command);
-            
+            var result = await handler.Handle(command);
+
             var url = $"{context.Request.Scheme}://{context.Request.Host}";
             url = $"{url}/users/verify?token={result.Value.VerifyToken}&email={result.Value.Email}";
             Console.WriteLine(url);
-            
-            result.Match(
+
+            return result.Match(
                 id => Results.Created($"users/{id}", id.UserId),
                 err => err.ToProblemDetails()
                 );
         });
 
-        grp.MapGet("/verify", async (string token, string email, IMediator mediator) =>
+        grp.MapGet("/verify", async (string token, string email, [FromServices] IRequestHandler<VerifyUser.Command, ErrorOr<Success>> handler) =>
         {
-            var result = await mediator.Send(new VerifyUser.Command(token, email));
-            
-            result.Match(
+            var result = await handler.Handle(new VerifyUser.Command(token, email));
+
+            return result.Match(
                 _ => Results.Ok(),
                 err => err.ToProblemDetails()
                 );

--- a/src/FSTime.Application/Authorization/AuthorizationErrors.cs
+++ b/src/FSTime.Application/Authorization/AuthorizationErrors.cs
@@ -23,4 +23,9 @@ public static class AuthorizationErrors
     {
         return Error.Conflict("PERMISSION_HANDLER.MY.ERROR", "When retrieving permissions an error occured: " + msg);
     }
+
+    public static Error GetActions_InvalidGroup(string grp)
+    {
+        return Error.Validation("GETACTIONS_HANDLER.GROUP_NOT_VALID", $"Group {grp} is not valid");
+    }
 }

--- a/src/FSTime.Application/Authorization/Commands/LoginUser.cs
+++ b/src/FSTime.Application/Authorization/Commands/LoginUser.cs
@@ -1,10 +1,9 @@
 ﻿using ErrorOr;
+using FlintSoft.CQRS;
 using FluentValidation;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Authorization;
 using FSTime.Domain.TenantAggregate;
-using MediatR;
-using Microsoft.AspNetCore.Identity;
 
 namespace FSTime.Application.Authorization.Commands;
 

--- a/src/FSTime.Application/Authorization/Commands/RefreshToken.cs
+++ b/src/FSTime.Application/Authorization/Commands/RefreshToken.cs
@@ -1,7 +1,7 @@
 ﻿using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Authorization;
-using MediatR;
 
 namespace FSTime.Application.Authorization.Commands;
 public static class RefreshToken

--- a/src/FSTime.Application/Authorization/Commands/RemoveAllPermissions.cs
+++ b/src/FSTime.Application/Authorization/Commands/RemoveAllPermissions.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.AuthorizationAggregate;
-using MediatR;
 
 namespace FSTime.Application.Authorization.Commands;
 

--- a/src/FSTime.Application/Authorization/Commands/RemovePermission.cs
+++ b/src/FSTime.Application/Authorization/Commands/RemovePermission.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.AuthorizationAggregate;
-using MediatR;
 
 namespace FSTime.Application.Authorization.Commands;
 

--- a/src/FSTime.Application/Authorization/Commands/SetPermission.cs
+++ b/src/FSTime.Application/Authorization/Commands/SetPermission.cs
@@ -1,8 +1,8 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FluentValidation;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.AuthorizationAggregate;
-using MediatR;
 
 namespace FSTime.Application.Authorization.Commands;
 

--- a/src/FSTime.Application/Authorization/Queries/GetActions.cs
+++ b/src/FSTime.Application/Authorization/Queries/GetActions.cs
@@ -1,9 +1,38 @@
 using ErrorOr;
-using MediatR;
+using FlintSoft.CQRS;
+using FSTime.Domain.AuthorizationAggregate;
 
 namespace FSTime.Application.Authorization.Queries;
 
 public static class GetActions
 {
     public record Query(string Group) : IRequest<ErrorOr<List<string>>>;
+
+    internal sealed class Handler : IRequestHandler<Query, ErrorOr<List<string>>>
+    {
+        public async Task<ErrorOr<List<string>>> Handle(Query request, CancellationToken cancellationToken = default)
+        {
+            var actions = new List<string>();
+
+            switch (request.Group)
+            {
+                case "EMPLOYEE":
+                    actions.Add(PermissionAction.Read.ToString());
+                    actions.Add(PermissionAction.Update.ToString());
+                    actions.Add(PermissionAction.Delete.ToString());
+                    break;
+
+                case "WORKSCHEDULE":
+                    actions.Add(PermissionAction.Read.ToString());
+                    actions.Add(PermissionAction.Update.ToString());
+                    actions.Add(PermissionAction.Delete.ToString());
+                    break;
+
+                default:
+                    return AuthorizationErrors.GetActions_InvalidGroup(request.Group);// Return an error if the group is not valid
+            }
+
+            return await Task.FromResult<ErrorOr<List<string>>>(actions);
+        }
+    }
 }

--- a/src/FSTime.Application/Authorization/Queries/GetGroups.cs
+++ b/src/FSTime.Application/Authorization/Queries/GetGroups.cs
@@ -1,6 +1,17 @@
+using ErrorOr;
+using FlintSoft.CQRS;
+
 namespace FSTime.Application.Authorization.Queries;
 
 public static class GetGroups
 {
-    public record Query;
+    public record Query() : IRequest<ErrorOr<List<string>>>;
+
+    internal sealed class Handler() : IRequestHandler<Query, ErrorOr<List<string>>>
+    {
+        public Task<ErrorOr<List<string>>> Handle(Query request, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<ErrorOr<List<string>>>(new List<string> { "EMPLOYEE", "WORKSCHEDULE" });
+        }
+    }
 }

--- a/src/FSTime.Application/Authorization/Queries/GetPermissionsForUser.cs
+++ b/src/FSTime.Application/Authorization/Queries/GetPermissionsForUser.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.AuthorizationAggregate;
-using MediatR;
 
 namespace FSTime.Application.Authorization.Queries;
 

--- a/src/FSTime.Application/Common/Interfaces/ITenantRepository.cs
+++ b/src/FSTime.Application/Common/Interfaces/ITenantRepository.cs
@@ -12,4 +12,5 @@ public interface ITenantRepository
     Task<Tenant> UpdateUserTenantRole(Guid tenantId, Guid userId, string role);
     Task<bool> RemoveUserFromTenant(Guid tenantId, Guid userId);
     Task<bool> IsTenantUser(Guid tenantId, Guid userId);
+    Task<bool> IsTenantAdmin(Guid tenantId, Guid userId);
 }

--- a/src/FSTime.Application/Companies/Commands/CreateCompany.cs
+++ b/src/FSTime.Application/Companies/Commands/CreateCompany.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.CompanyAggregate;
-using MediatR;
 
 namespace FSTime.Application.Companies.Commands;
 
@@ -19,12 +19,12 @@ public static class CreateCompany
                 var tenant = await tenantRepository.GetTenantById(request.TenantId);
                 if (tenant is null) return CompanyErrors.Create_Company_Tenant_NotFound();
                 if (!tenant.IsLicensed) return CompanyErrors.Create_Company_Tenant_NotLicences();
-                
+
                 //Prüfen ob es die Firma in diesem Tenant schon gibt
                 var companies = await companyRepository.GetCompaniesByTenant(request.TenantId);
                 if (companies.Any(x => x.Name == request.Name))
                     return CompanyErrors.Create_Company_Exists(request.Name);
-                
+
                 var company = new Company(request.Name, request.TenantId);
                 var result = await companyRepository.CreateCompany(company);
 

--- a/src/FSTime.Application/Companies/Queries/GetCompaniesByTenant.cs
+++ b/src/FSTime.Application/Companies/Queries/GetCompaniesByTenant.cs
@@ -1,14 +1,14 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.CompanyAggregate;
-using MediatR;
 
 namespace FSTime.Application.Companies.Queries;
 
 public static class GetCompaniesByTenant
 {
     public record Query(Guid TenantId) : IRequest<ErrorOr<List<Company>>>;
-    
+
     internal sealed class Handler(ICompanyRepository companyRepository) : IRequestHandler<Query, ErrorOr<List<Company>>>
     {
         public async Task<ErrorOr<List<Company>>> Handle(Query request, CancellationToken cancellationToken)

--- a/src/FSTime.Application/Employees/Commands/AddWorkschedule.cs
+++ b/src/FSTime.Application/Employees/Commands/AddWorkschedule.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
-using MediatR;
 
 namespace FSTime.Application.Employees.Commands;
 

--- a/src/FSTime.Application/Employees/Commands/AssignUserToEmployee.cs
+++ b/src/FSTime.Application/Employees/Commands/AssignUserToEmployee.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
-using MediatR;
 
 namespace FSTime.Application.Employees.Commands;
 

--- a/src/FSTime.Application/Employees/Commands/CreateEmployee.cs
+++ b/src/FSTime.Application/Employees/Commands/CreateEmployee.cs
@@ -1,8 +1,8 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
 using FSTime.Domain.EmployeeAggregate;
-using MediatR;
 
 namespace FSTime.Application.Employees.Commands;
 

--- a/src/FSTime.Application/Employees/Commands/SetEntryDate.cs
+++ b/src/FSTime.Application/Employees/Commands/SetEntryDate.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
-using MediatR;
 
 namespace FSTime.Application.Employees.Commands;
 

--- a/src/FSTime.Application/Employees/Commands/SetHead.cs
+++ b/src/FSTime.Application/Employees/Commands/SetHead.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
-using MediatR;
 
 namespace FSTime.Application.Employees.Commands;
 

--- a/src/FSTime.Application/Employees/Commands/SetSupervisor.cs
+++ b/src/FSTime.Application/Employees/Commands/SetSupervisor.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
-using MediatR;
 
 namespace FSTime.Application.Employees.Commands;
 

--- a/src/FSTime.Application/Employees/Queries/GetAllEmployees.cs
+++ b/src/FSTime.Application/Employees/Queries/GetAllEmployees.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
-using MediatR;
 
 namespace FSTime.Application.Employees.Queries;
 

--- a/src/FSTime.Application/Employees/Queries/GetEmployee.cs
+++ b/src/FSTime.Application/Employees/Queries/GetEmployee.cs
@@ -1,8 +1,8 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Employees;
 using FSTime.Contracts.Users;
-using MediatR;
 
 namespace FSTime.Application.Employees.Queries;
 

--- a/src/FSTime.Application/Extensions.cs
+++ b/src/FSTime.Application/Extensions.cs
@@ -1,5 +1,5 @@
-﻿using FluentValidation;
-using Microsoft.Extensions.DependencyInjection;
+﻿using FlintSoft.CQRS;
+using FluentValidation;
 using Microsoft.Extensions.Hosting;
 
 namespace FSTime.Application;
@@ -8,7 +8,8 @@ public static class Extensions
 {
     public static IHostApplicationBuilder? AddApplication(this IHostApplicationBuilder? host)
     {
-        host?.Services.AddMediatR(opt => opt.RegisterServicesFromAssemblyContaining(typeof(Extensions)));
+        //host?.Services.AddMediatR(opt => opt.RegisterServicesFromAssemblyContaining(typeof(Extensions)));
+        host?.AddFlintSoftCQRS(typeof(Extensions).Assembly);
         host?.Services.AddValidatorsFromAssembly(typeof(Extensions).Assembly);
         return host;
     }

--- a/src/FSTime.Application/FSTime.Application.csproj
+++ b/src/FSTime.Application/FSTime.Application.csproj
@@ -11,13 +11,13 @@
         <PackageReference Include="ErrorOr" Version="2.0.1" />
         <PackageReference Include="FluentValidation" Version="11.11.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-        <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.4" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\FlintSoft.CQRS\FlintSoft.CQRS.csproj" />
         <ProjectReference Include="..\FSTime.Contracts\FSTime.Contracts.csproj" />
         <ProjectReference Include="..\FSTime.Domain\FSTime.Domain.csproj" />
     </ItemGroup>

--- a/src/FSTime.Application/Tenants/Commands/AddUserToTenant.cs
+++ b/src/FSTime.Application/Tenants/Commands/AddUserToTenant.cs
@@ -1,8 +1,8 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Common.Exceptions.Tenants;
 using FSTime.Domain.TenantAggregate;
-using MediatR;
 
 namespace FSTime.Application.Tenants.Commands;
 

--- a/src/FSTime.Application/Tenants/Commands/CreateTenant.cs
+++ b/src/FSTime.Application/Tenants/Commands/CreateTenant.cs
@@ -1,16 +1,16 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FluentValidation;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.Common.ValueObjects;
 using FSTime.Domain.TenantAggregate;
-using MediatR;
 
 namespace FSTime.Application.Tenants.Commands;
 
 public static class CreateTenant
 {
     public record Command(string Name, Guid UserId) : IRequest<ErrorOr<Guid>>;
-    
+
     public class Validator : AbstractValidator<Command>
     {
         public Validator()

--- a/src/FSTime.Application/Tenants/Queries/GetTenantById.cs
+++ b/src/FSTime.Application/Tenants/Queries/GetTenantById.cs
@@ -1,14 +1,14 @@
-using FSTime.Domain.TenantAggregate;
-using MediatR;
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
+using FSTime.Domain.TenantAggregate;
 
 namespace FSTime.Application.Tenants.Queries;
 
 public static class GetTenantById
 {
     public record Query(Guid tenantId) : IRequest<ErrorOr<Tenant>>;
-    
+
     internal sealed class Handler(ITenantRepository tenantRepository) : IRequestHandler<Query, ErrorOr<Tenant>>
     {
         public async Task<ErrorOr<Tenant>> Handle(Query query, CancellationToken cancellationToken)

--- a/src/FSTime.Application/Tenants/Queries/GetUserTenant.cs
+++ b/src/FSTime.Application/Tenants/Queries/GetUserTenant.cs
@@ -1,14 +1,14 @@
-using FSTime.Domain.TenantAggregate;
-using MediatR;
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
+using FSTime.Domain.TenantAggregate;
 
 namespace FSTime.Application.Tenants.Queries;
 
 public static class GetUserTenant
 {
     public record Query(Guid userId) : IRequest<ErrorOr<Tenant>>;
-    
+
     internal sealed class Handler(ITenantRepository tenantRepository) : IRequestHandler<Query, ErrorOr<Tenant>>
     {
         public async Task<ErrorOr<Tenant>> Handle(Query query, CancellationToken cancellationToken)

--- a/src/FSTime.Application/Users/Commands/CreateUser.cs
+++ b/src/FSTime.Application/Users/Commands/CreateUser.cs
@@ -1,9 +1,9 @@
 ﻿using ErrorOr;
+using FlintSoft.CQRS;
 using FluentValidation;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Contracts.Users;
 using FSTime.Domain.UserAggregate;
-using MediatR;
 
 namespace FSTime.Application.Users.Commands;
 
@@ -40,12 +40,12 @@ public static class CreateUser
 
                 var pw = passwordService.HashPassword(request.password);
                 var verifyToken = tokenService.GenerateEmailVerificationToken();
-                
+
                 var user = new User(request.username, pw.password, request.email, pw.salt, verifyToken, DateTime.UtcNow.AddHours(2));
 
                 var res = await userRepository.AddUser(user);
-                
-                var ret  = new RegisterUserResult(res.Id, verifyToken, res.Email);
+
+                var ret = new RegisterUserResult(res.Id, verifyToken, res.Email);
                 return ret;
             }
             catch (Exception ex)

--- a/src/FSTime.Application/Users/Commands/VerifyUser.cs
+++ b/src/FSTime.Application/Users/Commands/VerifyUser.cs
@@ -1,14 +1,14 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
-using MediatR;
 
 namespace FSTime.Application.Users.Commands;
 
 public static class VerifyUser
 {
     public record Command(string token, string email) : IRequest<ErrorOr<Success>>;
-    
-    internal sealed class Handler(IUserRepository userRepository):IRequestHandler<Command, ErrorOr<Success>>
+
+    internal sealed class Handler(IUserRepository userRepository) : IRequestHandler<Command, ErrorOr<Success>>
     {
         public async Task<ErrorOr<Success>> Handle(Command request, CancellationToken cancellationToken)
         {
@@ -19,7 +19,7 @@ public static class VerifyUser
             {
                 return UserErrors.Verification_Token_Expired;
             }
-            
+
             user.SetVerified();
             await userRepository.UpdateUser(user);
 

--- a/src/FSTime.Application/Workschedules/Commands/CreateDailyWorkschedule.cs
+++ b/src/FSTime.Application/Workschedules/Commands/CreateDailyWorkschedule.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.WorkScheduleAggregate;
-using MediatR;
 
 namespace FSTime.Application.Workschedules.Commands;
 

--- a/src/FSTime.Application/Workschedules/Commands/CreateWeekWorkschedule.cs
+++ b/src/FSTime.Application/Workschedules/Commands/CreateWeekWorkschedule.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.WorkScheduleAggregate;
-using MediatR;
 
 namespace FSTime.Application.Workschedules.Commands;
 

--- a/src/FSTime.Application/Workschedules/Queries/GetWorkschedule.cs
+++ b/src/FSTime.Application/Workschedules/Queries/GetWorkschedule.cs
@@ -1,8 +1,8 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Application.Workschedules;
 using FSTime.Domain.WorkScheduleAggregate;
-using MediatR;
 
 namespace FSTime.Application.Workplans.Queries;
 

--- a/src/FSTime.Application/Workschedules/Queries/GetWorkschedules.cs
+++ b/src/FSTime.Application/Workschedules/Queries/GetWorkschedules.cs
@@ -1,7 +1,7 @@
 using ErrorOr;
+using FlintSoft.CQRS;
 using FSTime.Application.Common.Interfaces;
 using FSTime.Domain.WorkScheduleAggregate;
-using MediatR;
 
 namespace FSTime.Application.Workschedules.Queries;
 

--- a/src/FSTime.Contracts/FSTime.Contracts.csproj
+++ b/src/FSTime.Contracts/FSTime.Contracts.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0"/>
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.6.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.8.0" />
     </ItemGroup>
 
 </Project>

--- a/src/FSTime.Domain/AuthorizationAggregate/Permission.cs
+++ b/src/FSTime.Domain/AuthorizationAggregate/Permission.cs
@@ -9,8 +9,7 @@ public enum PermissionAction
     Unknown = 0,
     Read = 1,
     Update = 2,
-    Delete = 3,
-    All = 4
+    Delete = 3
 }
 
 public class Permission : AggregateRoot

--- a/src/FSTime.Domain/AuthorizationAggregate/Permission.cs
+++ b/src/FSTime.Domain/AuthorizationAggregate/Permission.cs
@@ -9,31 +9,22 @@ public enum PermissionAction
     Unknown = 0,
     Read = 1,
     Update = 2,
-    Delete = 3
+    Delete = 3,
+    All = 4
 }
 
 public class Permission : AggregateRoot
 {
-    public Permission(Guid tenantId, Guid userId, string group, PermissionAction action) : this(tenantId, userId, group)
+    public Permission(Guid tenantId, Guid userId, string group, PermissionAction action) : this(tenantId, userId)
     {
+        Group = group;
         Action = action;
     }
 
-    public Permission(Guid tenantId, User user, string group, PermissionAction action) : this(tenantId, user, group)
+    public Permission(Guid tenantId, User user, string group, PermissionAction action) : this(tenantId, user)
     {
+        Group = group;
         Action = action;
-    }
-
-    public Permission(Guid tenantId, Guid userId, string group) : this(tenantId, userId)
-    {
-        Group = group;
-        Action = PermissionAction.All;
-    }
-
-    public Permission(Guid tenantId, User user, string group) : this(tenantId, user)
-    {
-        Group = group;
-        Action = PermissionAction.All;
     }
 
     public Permission(Guid tenantId, Guid userId)

--- a/src/FSTime.Infrastructure/FSTime.Infrastructure.csproj
+++ b/src/FSTime.Infrastructure/FSTime.Infrastructure.csproj
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
+        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/FSTime.Infrastructure/Persistence/Repositories/TenantRepository.cs
+++ b/src/FSTime.Infrastructure/Persistence/Repositories/TenantRepository.cs
@@ -87,4 +87,11 @@ public class TenantRepository(FSTimeDbContext context) : ITenantRepository
             .Tenants
             .AnyAsync(x => x.Id == tenantId && x.Users.Any(y => y.UserId == userId));
     }
+
+    public async Task<bool> IsTenantAdmin(Guid tenantId, Guid userId)
+    {
+        return await context
+            .Tenants
+            .AnyAsync(x => x.Id == tenantId && x.Users.Any(y => y.UserId == userId && y.RoleName == "ADMIN"));
+    }
 }

--- a/src/FSTime.Infrastructure/Services/TokenService.cs
+++ b/src/FSTime.Infrastructure/Services/TokenService.cs
@@ -9,7 +9,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
-using FSTime.Domain.TenantAggregate;
 
 namespace FSTime.Infrastructure.Services;
 
@@ -28,7 +27,7 @@ public class TokenService(IDateTimeProvider dateTimeProvider, JwtSettings jwtSet
         {
             claims.Add(new Claim("TENANT", tenantId.ToString()!));
         }
-        
+
         var expiresAT = dateTimeProvider.UtcNow.AddMinutes(jwtSettings.AccessTokeExpiryMinutes ?? 0);
         var expiresRT = dateTimeProvider.UtcNow.AddMinutes(jwtSettings.RefreshTokeExpiryMinutes ?? 0);
 
@@ -46,10 +45,10 @@ public class TokenService(IDateTimeProvider dateTimeProvider, JwtSettings jwtSet
         {
             tokenHandler.ValidateToken(token, Utils.GetTokenValidationParameters(jwtSettings.Issuer!, jwtSettings.Audience!, jwtSettings.Secret!), out var securityToken);
             var jwtToken = tokenHandler.ReadJwtToken(token);
-            
+
             var userIdClaim = jwtToken.Claims.FirstOrDefault(x => x.Type == JwtRegisteredClaimNames.Sub);
             userId = userIdClaim?.Value;
-            
+
             var tenantIdClaim = jwtToken.Claims.FirstOrDefault(x => x.Type == "TENANT");
             tenantId = tenantIdClaim is not null ? Guid.Parse(tenantIdClaim.Value) : null;
             return true;
@@ -88,6 +87,6 @@ public class TokenService(IDateTimeProvider dateTimeProvider, JwtSettings jwtSet
             rng.GetBytes(tokenBytes);
         }
         var token = Convert.ToBase64String(tokenBytes);
-        return token;
+        return token.Normalize();
     }
 }

--- a/src/FSTime.Services.DatabaseMigration/FSTime.Services.DatabaseMigration.csproj
+++ b/src/FSTime.Services.DatabaseMigration/FSTime.Services.DatabaseMigration.csproj
@@ -8,9 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.1.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0"/>
+        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.2.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/InfrastructureTests/InfrastructureTests.csproj
+++ b/src/InfrastructureTests/InfrastructureTests.csproj
@@ -8,15 +8,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ServiceDefaults/ServiceDefaults.csproj
+++ b/src/ServiceDefaults/ServiceDefaults.csproj
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.2.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request introduces a new `FlintSoft.CQRS` library, integrates it into the `FSTime` solution, and replaces the use of `MediatR` with the new CQRS implementation across various API endpoints. Additionally, several package updates and project references were modified to support these changes.

### Key Changes:

#### Introduction of `FlintSoft.CQRS` Library:
* Added a new project `FlintSoft.CQRS` with interfaces `IRequest<TResponse>` and `IRequestHandler<TRequest, TResponse>` to define the CQRS pattern. (`FlintSoft.CQRS/IRequest.cs` - [[1]](diffhunk://#diff-a376a997bdaaa4cdab99f5932d98b2b5253d6dd2a4db4a3178d3b36cd3ac0c5aR1-R5) `FlintSoft.CQRS/IRequestHandler.cs` - [[2]](diffhunk://#diff-23deaf7973b006322c7933156cec158f3ca7d6f26295245a2809ce0af2eff549R1-R7)
* Implemented an extension method `AddFlintSoftCQRS` for registering request handlers from an assembly. (`FlintSoft.CQRS/Extensions.cs` - [FlintSoft.CQRS/Extensions.csR1-R29](diffhunk://#diff-bc74dfc0850a6ddb9202c6adaf52ff40ca466c498215e0a5e4715be806c5a0d5R1-R29))
* Created a project file for `FlintSoft.CQRS` targeting `.NET 9.0` with required dependencies. (`FlintSoft.CQRS/FlintSoft.CQRS.csproj` - [FlintSoft.CQRS/FlintSoft.CQRS.csprojR1-R13](diffhunk://#diff-84583310c0d2c175867bd6bd93c82a8571ad1cf3889697cd0f7ab2b9a7a712dfR1-R13))

#### Integration of `FlintSoft.CQRS` into `FSTime` Solution:
* Added `FlintSoft.CQRS` to the solution file (`FSTime.sln`) and configured build settings. [[1]](diffhunk://#diff-22118caf4b20f2e7306d1adb6dabdba39d2b9b3d3c8cc100a8a465fe641f045bR27-R30) [[2]](diffhunk://#diff-22118caf4b20f2e7306d1adb6dabdba39d2b9b3d3c8cc100a8a465fe641f045bR73-R76) [[3]](diffhunk://#diff-22118caf4b20f2e7306d1adb6dabdba39d2b9b3d3c8cc100a8a465fe641f045bR85)
* Updated `FSTime.Api` to reference `FlintSoft.CQRS` and replaced `MediatR` with `FlintSoft.CQRS` in API endpoints for handling commands and queries. (`src/FSTime.Api/FSTime.Api.csproj` - [[1]](diffhunk://#diff-2498f3cc3dde601b2aa5b36d7df7d28375bb45e65d25626549b01917ca6a38f7L12-R21) `src/FSTime.Api/Authorization/Endpoints.cs` - [[2]](diffhunk://#diff-90a110b95a30f2efd19c3a14dc24e152337e7c35a813edfed2729230743ed011L17-R27) [[3]](diffhunk://#diff-90a110b95a30f2efd19c3a14dc24e152337e7c35a813edfed2729230743ed011L43-R49)

#### Refactoring API Endpoints:
* Replaced `IMediator` with `IRequestHandler` in endpoints across multiple modules, including Authorization, Permissions, Companies, Employees, and Tenants. (`src/FSTime.Api/Authorization/PermissionEndpoints.cs` - [[1]](diffhunk://#diff-5f196c492245cf3c1c7eb2dba7398ea0ac4b7715910521a01ccd89f0b16f5f54R1-R9) `src/FSTime.Api/Companies/Endpoints.cs` - [[2]](diffhunk://#diff-81b4ce7936a60724be631718870a9bc9382e7dfc324bfdbffaec6aa38fa4fcf1R1-R10) `src/FSTime.Api/Employees/Endpoints.cs` - [[3]](diffhunk://#diff-cf381d80781dca93427046b6c88624174dc482a8f38acdb3a7da74a476c7cdf7R1-L7) `src/FSTime.Api/Tenants/Endpoints.cs` - [[4]](diffhunk://#diff-497912480952219aa22472258fa5334e67c737be59e1f88fc97db4cee8d17507L18-R21)
* Introduced new endpoints for managing groups and actions in the Permissions module. (`src/FSTime.Api/Authorization/PermissionEndpoints.cs` - [src/FSTime.Api/Authorization/PermissionEndpoints.csL24-R65](diffhunk://#diff-5f196c492245cf3c1c7eb2dba7398ea0ac4b7715910521a01ccd89f0b16f5f54L24-R65))

#### Dependency and Package Updates:
* Upgraded several NuGet packages, including `Microsoft.AspNetCore.Authentication.JwtBearer` and `System.IdentityModel.Tokens.Jwt`, to their latest versions. (`src/AppHost/AppHost.csproj` - [[1]](diffhunk://#diff-b567b7f5c14c731999a08ea97ea0b852616628d6f0bff81e1bc3761f1b05564cL16-R18) `src/FSTime.Api/FSTime.Api.csproj` - [[2]](diffhunk://#diff-2498f3cc3dde601b2aa5b36d7df7d28375bb45e65d25626549b01917ca6a38f7L12-R21)

#### Miscellaneous Changes:
* Removed unused `FSTime.Api` dependency imports and added the `FlintSoft.CQRS` registration in the program initialization. (`src/FSTime.Api/Program.cs` - [src/FSTime.Api/Program.csL6](diffhunk://#diff-706b7458e69b3a3c73f42f6b390a5a0e2943f0b1ea31064622d4bb47deb3e864L6))